### PR TITLE
Update CVE-2024-27198.json

### DIFF
--- a/2024/CVE-2024-27198.json
+++ b/2024/CVE-2024-27198.json
@@ -251,29 +251,6 @@
 			"pushed_at": "2024-07-20T17:28:41Z",
 			"updated_at": "2024-07-20T17:28:45Z",
 			"visibility": "public"
-		},
-		{
-			"allow_forking": true,
-			"created_at": "2024-08-12T04:46:34Z",
-			"description": "CVE-2024-27198 & CVE-2024-27199 PoC - RCE, Admin Account Creation, Enum Users, Server Information  #RCE #python3",
-			"forks": 2,
-			"forks_count": 2,
-			"full_name": "Pypi-Project/RCity-CVE-2024-27198",
-			"html_url": "https://github.com/Pypi-Project/RCity-CVE-2024-27198",
-			"id": 841276603,
-			"name": "RCity-CVE-2024-27198",
-			"owner": {
-				"avatar_url": "https://avatars.githubusercontent.com/u/177478126?v=4",
-				"html_url": "https://github.com/Pypi-Project",
-				"id": 177478126,
-				"login": "Pypi-Project"
-			},
-			"pushed_at": "2024-08-12T04:47:04Z",
-			"stargazers_count": 4,
-			"updated_at": "2024-08-13T04:31:18Z",
-			"visibility": "public",
-			"watchers": 4,
-			"watchers_count": 4
 		}
 	]
 }


### PR DESCRIPTION
One malicious Poc project: https://github.com/Pypi-Project/RCity-CVE-2024-27198 was removed
Analysis and screenshots from my post: https://x.com/AabyssZG/status/1823247212119519517